### PR TITLE
add best_model_path to TrainOutput

### DIFF
--- a/torchrecipes/core/base_train_app.py
+++ b/torchrecipes/core/base_train_app.py
@@ -35,6 +35,7 @@ OmegaConf.register_new_resolver("get_method", hydra.utils.get_method)
 @dataclass
 class TrainOutput:
     tensorboard_log_dir: Optional[str] = None
+    best_model_path: Optional[str] = None
 
 
 class TestOutput(TypedDict):
@@ -56,6 +57,7 @@ class BaseTrainApp:
     trainer_conf: TrainerConf
     log_dir: Optional[str]
     root_dir: Optional[str]
+    _checkpoint_callback: Optional[OSSModelCheckpoint]
 
     def __init__(
         self,
@@ -73,6 +75,7 @@ class BaseTrainApp:
         self.trainer_conf = trainer
         self.log_dir = None
         self.root_dir = None
+        self._checkpoint_callback = None
         torch._C._log_api_usage_once(
             f"torchrecipes.{self.__module__}.{self.__class__.__name__}"
         )
@@ -157,14 +160,15 @@ class BaseTrainApp:
 
         # create default model checkpoint callback unless disabled
         if trainer_params.get("checkpoint_callback", True):
-            checkpoint_callback = self.get_default_model_checkpoint()
-            callbacks.append(checkpoint_callback)
+            self._checkpoint_callback = self.get_default_model_checkpoint()
+            callbacks.append(self._checkpoint_callback)
 
             # auto-resume from last default checkpoint
-            ckpt_path = checkpoint_callback.dirpath
-            if not trainer_params.get("resume_from_checkpoint") and ckpt_path:
-                last_checkpoint = find_last_checkpoint_path(ckpt_path)
-                trainer_params["resume_from_checkpoint"] = last_checkpoint
+            if self._checkpoint_callback:
+                ckpt_path = self._checkpoint_callback.dirpath
+                if not trainer_params.get("resume_from_checkpoint") and ckpt_path:
+                    last_checkpoint = find_last_checkpoint_path(ckpt_path)
+                    trainer_params["resume_from_checkpoint"] = last_checkpoint
 
         trainer_params["callbacks"] = callbacks
 
@@ -192,8 +196,14 @@ class BaseTrainApp:
             log_params["run_status"] = JobStatus.FAILED.value
             log_run(**log_params)
             raise got_exception
-
-        return TrainOutput(tensorboard_log_dir=self.log_dir)
+        best_model_path = (
+            self._checkpoint_callback.best_model_path
+            if self._checkpoint_callback
+            else None
+        )
+        return TrainOutput(
+            tensorboard_log_dir=self.log_dir, best_model_path=best_model_path
+        )
 
     def test(self) -> _EVALUATE_OUTPUT:
         trainer, _ = self._get_trainer()

--- a/torchrecipes/vision/image_classification/tests/test_train_app.py
+++ b/torchrecipes/vision/image_classification/tests/test_train_app.py
@@ -46,7 +46,10 @@ class TestTrainApp(BaseTrainAppTestCase):
     def test_train_model(self, root_dir: str) -> None:
         train_app = self._get_train_app(tb_save_dir=root_dir)
         # Train the model with the config
-        train_app.train()
+        output = train_app.train()
+        self.assertIsNotNone(output.tensorboard_log_dir)
+        # we don't save checkpoints for tests, because it would make the tests flaky
+        self.assertIsNone(output.best_model_path)
 
     @tempdir
     def test_fine_tuning(self, root_dir: str) -> None:


### PR DESCRIPTION
Summary: It's useful to return the best_model_path after training. e.g. F6 + multimodality needs it to publish the best model

Differential Revision: D33716125

