### PR TITLE
Add callout items to the Docs landing page (#12196)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ Pygments==2.10.0
 pyparsing==2.4.7
 pyre-extensions==0.0.23
 # For core development, take a dependency on master branch.
-pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning.git@86b177ebe
+pytorch-lightning @ git+https://github.com/PyTorchLightning/pytorch-lightning.git@9b011606f
 PyYAML==6.0
 requests==2.26.0
 requests-oauthlib==1.3.0


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/ReAgent/pull/616

### New commit log messages
- [9b011606f Add callout items to the Docs landing page (#12196)](https://github.com/PyTorchLightning/pytorch-lightning/pull/12196)

Reviewed By: edward-io

Differential Revision: D34687261

