### PR TITLE
Modifying interaction layer to include 2 MLPs in DLRM

### DIFF
--- a/torchrecipes/rec/modules/lightning_dlrm.py
+++ b/torchrecipes/rec/modules/lightning_dlrm.py
@@ -19,7 +19,7 @@ from torchrec import EmbeddingBagCollection
 from torchrec.distributed import TrainPipelineSparseDist
 from torchrec.distributed.model_parallel import DistributedModelParallel
 from torchrec.distributed.train_pipeline import In
-from torchrec.models.dlrm import DLRMTrain
+from torchrec.models.dlrm import DLRM, DLRMTrain
 from torchrec.optim.keyed import KeyedOptimizerWrapper
 
 
@@ -53,13 +53,14 @@ class LightningDLRM(pl.LightningModule):
             dist.init_process_group(backend=backend)
         self.to(device=device)
 
-        model = DLRMTrain(
+        dlrm_model = DLRM(
             embedding_bag_collection=embedding_bag_collection,
             dense_in_features=dense_in_features,
             dense_arch_layer_sizes=dense_arch_layer_sizes,
             over_arch_layer_sizes=over_arch_layer_sizes,
             dense_device=device,
         )
+        model = DLRMTrain(dlrm_model)
 
         self.model = DistributedModelParallel(
             module=model,


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/382

X-link: https://github.com/facebookresearch/dlrm/pull/242

This diff adds 2 MLPs to the interaction layer in DLRM for MLPerf update. New DLRM module called DLRMV2 can be realized by --dlrmv2 argument. Additional arguments for the interaction MLPs are --interaction_branch1_layer_sizes and --interaction_branch2_layer_sizes to pass in the MLP sizes. The output dimension of the interaction MLPs must be a multiple of the embedding dimension.

DLRMTrain now takes in a DLRM/DLRMV2 module at construction time.

Reviewed By: colin2328, samiwilf

Differential Revision: D35861688

