### PR TITLE
Export transform and model for torchscript, quantization and deployment

### DIFF
--- a/torchrecipes/paved_path/README.md
+++ b/torchrecipes/paved_path/README.md
@@ -9,9 +9,10 @@ pip install -r requirements.txt
 ```
 
 2. Model training
-* Train a model
+* Train a GPT model for char generation task.
 ```bash
-python charnn/main.py
+cd charnn
+python main.py trainer.job_name=my_job
 ```
 You will get output like below. The snapshot path can be used for inference or restore training
 ```
@@ -21,23 +22,26 @@ You will get output like below. The snapshot path can be used for inference or r
 0: epoch 0 iter 100: test loss 2.69960
 0: epoch 0 iter 200: test loss 2.70585
 ...
-[2022-08-30 20:07:33,842][trainer][INFO] - Saving snapshot to /tmp/charnn/run-bc6565c7/snapshots/epoch-1
+[2022-10-12 21:30:50,161][trainer][INFO] - Saving snapshot to /tmp/charnn/my_job/snapshots/last
+[2022-10-12 21:30:50,161][__main__][INFO] - Saving CombinedModule to /tmp/charnn/my_job/modules/last.pt
 ```
-* Restore from a snapshot and train with more epochs
+* [Optional] train the model with torchx. It's especially useful for multi-node multi-GPU training and
+you can switch between various clusters/schedulers easily.
 ```bash
-python charnn/main.py trainer.max_epochs=3 trainer.snapshot_path=/tmp/charnn/run-1f7abaed/snapshots/epoch-1
-```
-
-3. Generate text from a model
-```bash
-python charnn/main.py charnn.task="generate" charnn.phrase="hello world" trainer.snapshot_path=/tmp/charnn/run-1f7abaed/snapshots/epoch-1
-```
-
-4. [Optional] train a model with torchx
-```bash
-torchx run  -s local_cwd dist.ddp -j 1x2 --script charnn/main.py
+torchx run  -s local_cwd dist.ddp -j 1x2 --script main.py
 ```
 > **_NOTE_**: `-j 1x2` specifies single node with 2 GPUs. Learn more about torchx [here](https://pytorch.org/torchx/latest/)
+
+* Resume training from a snapshot and train with more epochs
+```bash
+python main.py trainer.max_epochs=3 trainer.snapshot_path=/tmp/charnn/my_job/snapshots/last
+```
+
+3. Model transformation.
+* Export the module with torchscript. Optionally, you can append `--quantize` to quantize the model.
+```bash
+python export.py --input_path /tmp/charnn/my_job/modules/last.pt --output_path /tmp/charnn/my_job/modules/export.pt --torchscript
+```
 
 ## Development in AWS
 ### Setup environment

--- a/torchrecipes/paved_path/charnn/char_dataset.py
+++ b/torchrecipes/paved_path/charnn/char_dataset.py
@@ -7,48 +7,30 @@
 
 from typing import Tuple
 
-import fsspec
 import torch
 from torch.utils.data import Dataset
+
+from char_transform import CharTransform
 
 
 class CharDataset(Dataset):
     """Character dataset"""
-
     def __init__(self, data_path: str, block_size: int) -> None:
-        self._init_data(data_path, block_size)
+        # self._init_data(data_path, block_size)
+        self.block_size = block_size
+        self.transform = CharTransform(data_path)
+        self.data = self.transform.data
+        self.vocab_size = self.transform.vocab_size
 
     def __len__(self) -> int:
-        return self.data_size - self.block_size
+        return self.transform.data_size - self.block_size
 
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
-        return self._getitem(idx)
-
-    def _init_data(self, data_path: str, block_size: int) -> None:
-        fs, path = fsspec.core.url_to_fs(data_path)
-        with fs.open(path, "r") as f:
-            self.data = f.read()
-        self.data_path = data_path
-        self.block_size = block_size
-        chars = sorted(set(self.data))
-        self.data_size = len(self.data)
-        self.vocab_size = len(chars)
-        print(f"Data has {self.data_size} characters, {self.vocab_size} unique.")
-        self.stoi = {ch: i for i, ch in enumerate(chars)}
-        self.itos = {i: ch for i, ch in enumerate(chars)}
-
-    def _getitem(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
         # grab a chunk of (block_size + 1) characters from the data
-        chunk = self.data[idx : idx + self.block_size + 1]
+        chunk = self.data[idx: idx + self.block_size + 1]
         # encode every character to an integer
-        dix = [self.stoi[s] for s in chunk]
-        x = torch.tensor(dix[:-1], dtype=torch.long)
-        y = torch.tensor(dix[1:], dtype=torch.long)
+        # dix = [self.stoi[s] for s in chunk]
+        ids = self.transform(chunk)
+        x = torch.tensor(ids[:-1], dtype=torch.long)
+        y = torch.tensor(ids[1:], dtype=torch.long)
         return (x, y)
-
-
-def get_dataset(data_path: str, block_size: int) -> Dataset:
-    """
-    Get a dataset by name and config. Will be extended to support more datasets
-    """
-    return CharDataset(data_path, block_size)

--- a/torchrecipes/paved_path/charnn/char_transform.py
+++ b/torchrecipes/paved_path/charnn/char_transform.py
@@ -10,6 +10,7 @@ from typing import List
 import fsspec
 import torch
 import torch.nn as nn
+from torch import Tensor
 
 
 class CharTransform(nn.Module):
@@ -26,12 +27,15 @@ class CharTransform(nn.Module):
         self.stoi = {ch: i for i, ch in enumerate(chars)}
         self.itos = {i: ch for i, ch in enumerate(chars)}
 
-    def forward(self, text: str):
+    def forward(self, text: str) -> Tensor:
         return self.encode(text)
 
-    def encode(self, text: str):
+    def encode(self, text: str) -> Tensor:
+        # Unsqueeze the input because GPT model expects a batch of inputs.
         ids = [self.stoi[s] for s in text]
         return torch.tensor(ids, dtype=torch.long)
 
-    def decode(self, ids: List[int]):
-        return "".join([self.itos[i] for i in ids])
+    def decode(self, ids: Tensor) -> str:
+        # Squeeze model output because GPT model returns a batch of ouputs.
+        token_ids: List[int] = ids.tolist()
+        return "".join([self.itos[i] for i in token_ids])

--- a/torchrecipes/paved_path/charnn/char_transform.py
+++ b/torchrecipes/paved_path/charnn/char_transform.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List
+
+import fsspec
+import torch
+import torch.nn as nn
+
+
+class CharTransform(nn.Module):
+    def __init__(self, data_path: str):
+        super().__init__()
+        fs, path = fsspec.core.url_to_fs(data_path)
+        with fs.open(path, "r") as f:
+            self.data = f.read()
+        self.data_path = data_path
+        chars = sorted(set(self.data))
+        self.data_size = len(self.data)
+        self.vocab_size = len(chars)
+        print(f"Data has {self.data_size} characters, {self.vocab_size} unique.")
+        self.stoi = {ch: i for i, ch in enumerate(chars)}
+        self.itos = {i: ch for i, ch in enumerate(chars)}
+
+    def forward(self, text: str):
+        return self.encode(text)
+
+    def encode(self, text: str):
+        ids = [self.stoi[s] for s in text]
+        return torch.tensor(ids, dtype=torch.long)
+
+    def decode(self, ids: List[int]):
+        return "".join([self.itos[i] for i in ids])

--- a/torchrecipes/paved_path/charnn/combined_module.py
+++ b/torchrecipes/paved_path/charnn/combined_module.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+CombinedModule includes model and its corresponding transform.
+It's mainly used for inference from raw inputs, which will be converted
+to tensors by transform then pass to model.
+"""
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.nn import functional as F
+
+
+class CombinedModule(nn.Module):
+    device: str
+
+    def __init__(self, transform: nn.Module, model: nn.Module) -> None:
+        super().__init__()
+        self.transform = transform
+        self.model = model
+        self.device = ""
+
+    def forward(self, text: str) -> str:
+        tokens = self.transform(text)
+        tokens = tokens.unsqueeze(0).to(self.device)
+        generated_ids = self.generate(tokens).squeeze()
+        return self.transform.decode(generated_ids)
+
+    @torch.jit.export
+    def set_device(self, device: str) -> None:
+        self.device = device
+
+    def top_k_logits(self, logits: Tensor, k: int) -> Tensor:
+        v, ix = torch.topk(logits, k)
+        out = logits.clone()
+        out[out < v[:, [-1]]] = -float("Inf")
+        return out
+
+    def generate(
+        self,
+        x: Tensor,
+        steps: int = 100,
+        temperature: float = 1.0,
+        sample: bool = True,
+        top_k: Optional[int] = 10,
+    ) -> Tensor:
+        """
+        take a conditioning sequence of indices in x (of shape (b,t)) and predict the next token in
+        the sequence, feeding the predictions back into the model each time. Clearly the sampling
+        has quadratic complexity unlike an RNN that is only linear, and has a finite context window
+        of block_size, unlike an RNN that has an infinite context window.
+        """
+        block_size = 128
+        for _ in range(steps):
+            x_cond = (
+                x if x.size(1) <= block_size else x[:, -block_size:]
+            )  # crop context if needed
+            logits = self.model(x_cond)
+            # pluck the logits at the final step and scale by temperature
+            logits = logits[:, -1, :] / temperature
+            # optionally crop probabilities to only the top k options
+            if top_k is not None:
+                logits = self.top_k_logits(logits, top_k)
+            # apply softmax to convert to probabilities
+            probs = F.softmax(logits, dim=-1)
+            # sample from the distribution or take the most likely
+            if sample:
+                ix = torch.multinomial(probs, num_samples=1)
+            else:
+                _, ix = torch.topk(probs, k=1, dim=-1)
+            # append to the sequence and continue
+            x = torch.cat((x, ix), dim=1)
+
+        return x

--- a/torchrecipes/paved_path/charnn/export.py
+++ b/torchrecipes/paved_path/charnn/export.py
@@ -9,8 +9,6 @@ import argparse
 import fsspec
 import torch
 
-from model import GPT, GPTConfig
-
 parser = argparse.ArgumentParser(description="Quantize the model from a snapshot")
 parser.add_argument(
     "-i",
@@ -26,21 +24,6 @@ parser.add_argument(
     required=True,
     help="Snapshot path to save. It can be a local path, S3 or Google Cloud Storage URL",
 )
-parser.add_argument(
-    "-v", "--vocab_size", type=int, default=65, help="vocab size for the model"
-)
-parser.add_argument(
-    "-b", "--block_size", type=int, default=128, help="block size for the model"
-)
-parser.add_argument(
-    "-l", "--n_layer", type=int, default=2, help="number of layers for the model"
-)
-parser.add_argument(
-    "-d", "--n_head", type=int, default=2, help="number of heads for the model"
-)
-parser.add_argument(
-    "-e", "--n_embd", type=int, default=32, help="size of embedding for the model"
-)
 parser.add_argument("-q", "--quantize", help="quantize the model", action="store_true")
 parser.add_argument(
     "-t", "--torchscript", help="torchscript the model", action="store_true"
@@ -50,18 +33,9 @@ parser.add_argument(
 def main() -> None:
     args = parser.parse_args()
 
-    mconf = GPTConfig(
-        vocab_size=args.vocab_size,
-        block_size=args.block_size,
-        n_layer=args.n_layer,
-        n_head=args.n_head,
-        n_embd=args.n_embd,
-    )
-    model = GPT(mconf)
-
     fs, intput_path = fsspec.core.url_to_fs(args.input_path)
     with fs.open(intput_path, "rb") as f:
-        model.load_state_dict(torch.load(f, map_location="cpu"))
+        model = torch.load(f, map_location="cpu")
 
     # quantize the model. Note that dynamic Quantization currently only
     # supports nn.Linear and nn.LSTM in qconfig_spec
@@ -79,7 +53,8 @@ def main() -> None:
             torch.jit.save(model_jit, f)
         else:
             torch.save(model, f)
-    print(f"exported model to {args.output_path}")
+
+    print(f"exported the module to {args.output_path}")
 
 
 if __name__ == "__main__":

--- a/torchrecipes/paved_path/charnn/export.py
+++ b/torchrecipes/paved_path/charnn/export.py
@@ -21,8 +21,8 @@ parser.add_argument("-b", "--block_size", type=int, default=128, help="block siz
 parser.add_argument("-l", "--n_layer", type=int, default=2, help="number of layers for the model")
 parser.add_argument("-d", "--n_head", type=int, default=2, help="number of heads for the model")
 parser.add_argument("-e", "--n_embd", type=int, default=32, help="size of embedding for the model")
-parser.add_argument("-q", "--quantize", type=bool, default=True, help="quantize the model")
-parser.add_argument("-t", "--torchscript", type=bool, default=False, help="torchscript the model")
+parser.add_argument("-q", "--quantize", help="quantize the model", action='store_true')
+parser.add_argument("-t", "--torchscript", help="torchscript the model", action='store_true')
 
 
 def main() -> None:
@@ -44,12 +44,14 @@ def main() -> None:
     # quantize the model. Note that dynamic Quantization currently only 
     # supports nn.Linear and nn.LSTM in qconfig_spec
     if args.quantize:
+        print("quantizing the model...")
         model = torch.quantization.quantize_dynamic(
             model, qconfig_spec={torch.nn.Linear}, dtype=torch.qint8
         )
     # torchscript the model. Note that minGPT model in this example is
     # not torchscriptable yet.
     if args.torchscript:
+        print("torchscripting the model...")
         model = torch.jit.script(model)
 
     fs, output_path = fsspec.core.url_to_fs(args.output_path)

--- a/torchrecipes/paved_path/charnn/export.py
+++ b/torchrecipes/paved_path/charnn/export.py
@@ -12,17 +12,39 @@ import torch
 from model import GPT, GPTConfig
 
 parser = argparse.ArgumentParser(description="Quantize the model from a snapshot")
-parser.add_argument("-i", "--input_path", type=str, required=True,
-                    help="Snapshot path to load. It can be a local path, S3 or Google Cloud Storage URL")
-parser.add_argument("-o", "--output_path", type=str, required=True,
-                    help="Snapshot path to save. It can be a local path, S3 or Google Cloud Storage URL")
-parser.add_argument("-v", "--vocab_size", type=int, default=65, help="vocab size for the model")
-parser.add_argument("-b", "--block_size", type=int, default=128, help="block size for the model")
-parser.add_argument("-l", "--n_layer", type=int, default=2, help="number of layers for the model")
-parser.add_argument("-d", "--n_head", type=int, default=2, help="number of heads for the model")
-parser.add_argument("-e", "--n_embd", type=int, default=32, help="size of embedding for the model")
-parser.add_argument("-q", "--quantize", help="quantize the model", action='store_true')
-parser.add_argument("-t", "--torchscript", help="torchscript the model", action='store_true')
+parser.add_argument(
+    "-i",
+    "--input_path",
+    type=str,
+    required=True,
+    help="Snapshot path to load. It can be a local path, S3 or Google Cloud Storage URL",
+)
+parser.add_argument(
+    "-o",
+    "--output_path",
+    type=str,
+    required=True,
+    help="Snapshot path to save. It can be a local path, S3 or Google Cloud Storage URL",
+)
+parser.add_argument(
+    "-v", "--vocab_size", type=int, default=65, help="vocab size for the model"
+)
+parser.add_argument(
+    "-b", "--block_size", type=int, default=128, help="block size for the model"
+)
+parser.add_argument(
+    "-l", "--n_layer", type=int, default=2, help="number of layers for the model"
+)
+parser.add_argument(
+    "-d", "--n_head", type=int, default=2, help="number of heads for the model"
+)
+parser.add_argument(
+    "-e", "--n_embd", type=int, default=32, help="size of embedding for the model"
+)
+parser.add_argument("-q", "--quantize", help="quantize the model", action="store_true")
+parser.add_argument(
+    "-t", "--torchscript", help="torchscript the model", action="store_true"
+)
 
 
 def main() -> None:
@@ -41,22 +63,22 @@ def main() -> None:
     with fs.open(intput_path, "rb") as f:
         model.load_state_dict(torch.load(f, map_location="cpu"))
 
-    # quantize the model. Note that dynamic Quantization currently only 
+    # quantize the model. Note that dynamic Quantization currently only
     # supports nn.Linear and nn.LSTM in qconfig_spec
     if args.quantize:
         print("quantizing the model...")
         model = torch.quantization.quantize_dynamic(
             model, qconfig_spec={torch.nn.Linear}, dtype=torch.qint8
         )
-    # torchscript the model. Note that minGPT model in this example is
-    # not torchscriptable yet.
-    if args.torchscript:
-        print("torchscripting the model...")
-        model = torch.jit.script(model)
 
     fs, output_path = fsspec.core.url_to_fs(args.output_path)
     with fs.open(output_path, "wb") as f:
-        torch.save(model, f)
+        if args.torchscript:
+            print("torchscripting the model...")
+            model_jit = torch.jit.script(model)
+            torch.jit.save(model_jit, f)
+        else:
+            torch.save(model, f)
     print(f"exported model to {args.output_path}")
 
 

--- a/torchrecipes/paved_path/charnn/main.py
+++ b/torchrecipes/paved_path/charnn/main.py
@@ -121,7 +121,8 @@ def main(cfg: DictConfig) -> None:
     device = get_device()
     setup_process_group()
 
-    job_name = get_job_name()
+    train_cfg = cfg["trainer"]
+    job_name = train_cfg["job_name"] if train_cfg.get("job_name") else get_job_name()
     data_path = get_realpath(cfg["dataset"]["path"])
     logger.info(
         f"{get_fq_hostname()}:{os.getpid()}:{device} Running charNN {job_name}, data_path: {data_path}"
@@ -144,7 +145,6 @@ def main(cfg: DictConfig) -> None:
         n_embd=cfg["model"]["n_embd"],
     )
 
-    train_cfg = cfg["trainer"]
     train_cfg["work_dir"] = os.path.join(train_cfg.get("work_dir", ""), job_name)
     tconf = TrainerConfig(
         work_dir=train_cfg["work_dir"],

--- a/torchrecipes/paved_path/charnn/main.py
+++ b/torchrecipes/paved_path/charnn/main.py
@@ -16,7 +16,7 @@ import torch
 import torch.distributed as dist
 import torchsnapshot
 
-from char_dataset import CharDataset, get_dataset
+from char_dataset import CharDataset
 from model import GPT, GPTConfig, OptimizerConfig
 from omegaconf import DictConfig
 from torch.nn.parallel import DistributedDataParallel
@@ -128,7 +128,7 @@ def main(cfg: DictConfig) -> None:
         f"{get_fq_hostname()}:{os.getpid()}:{device} Running charNN {job_name}, data_path: {data_path}"
     )
     block_size = 128  # spatial extent of the model for its context
-    dataset = get_dataset(data_path, block_size)
+    dataset = CharDataset(data_path, block_size)
 
     data_len = len(dataset)
     train_len = int(data_len * 0.9)

--- a/torchrecipes/paved_path/charnn/model.py
+++ b/torchrecipes/paved_path/charnn/model.py
@@ -176,7 +176,7 @@ class GPT(nn.Module):
             module.weight.data.fill_(1.0)
 
     def forward(self, idx: Tensor) -> Tensor:
-        b, t = idx.size()
+        _, t = idx.size()
         assert t <= self.block_size, "Cannot forward, model block size is exhausted."
 
         # forward the GPT model

--- a/torchrecipes/paved_path/charnn/model.py
+++ b/torchrecipes/paved_path/charnn/model.py
@@ -18,7 +18,6 @@ GPT model:
 import logging
 import os
 from dataclasses import dataclass
-from typing import Tuple
 
 import torch
 import torch.nn as nn
@@ -27,7 +26,6 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper,
 )
 from torch.distributed.fsdp.wrap import wrap
-from torch.nn import functional as F
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +76,7 @@ class EmbeddingStem(nn.Module):
     def reset_parameters(self) -> None:
         self.tok_emb.reset_parameters()
 
-    def forward(self, idx) -> Tensor:
+    def forward(self, idx: Tensor) -> Tensor:
         b, t = idx.size()
         assert t <= self.block_size, "Cannot forward, model block size is exhausted."
 
@@ -177,7 +175,7 @@ class GPT(nn.Module):
             module.bias.data.zero_()
             module.weight.data.fill_(1.0)
 
-    def forward(self, idx, targets=None) -> Tuple[Tensor, Tensor]:
+    def forward(self, idx: Tensor) -> Tensor:
         b, t = idx.size()
         assert t <= self.block_size, "Cannot forward, model block size is exhausted."
 
@@ -186,8 +184,4 @@ class GPT(nn.Module):
         x = self.blocks(x)
         x = self.ln_f(x)
         logits = self.head(x)
-        loss = None
-        if targets is not None:
-            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
-
-        return logits, loss
+        return logits

--- a/torchrecipes/paved_path/charnn/quantize.py
+++ b/torchrecipes/paved_path/charnn/quantize.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import argparse
+
+import torch
+
+from model import GPT, GPTConfig
+from utils import get_filesystem
+
+parser = argparse.ArgumentParser(description="Quantize the model from a snapshot")
+parser.add_argument("-i", "--input_path", type=str, required=True,
+                    help="Snapshot path to load. It can be a local path, S3 or Google Cloud Storage URL")
+parser.add_argument("-o", "--output_path", type=str, required=True,
+                    help="Snapshot path to save. It can be a local path, S3 or Google Cloud Storage URL")
+parser.add_argument("-v", "--vocab_size", type=int, default=65, help="vocab size for the model")
+parser.add_argument("-b", "--block_size", type=int, default=128, help="block size for the model")
+parser.add_argument("-l", "--n_layer", type=int, default=2, help="number of layers for the model")
+parser.add_argument("-d", "--n_head", type=int, default=2, help="number of heads for the model")
+parser.add_argument("-e", "--n_embd", type=int, default=32, help="size of embedding for the model")
+
+
+def main() -> None:
+    args = parser.parse_args()
+
+    mconf = GPTConfig(
+        vocab_size=args.vocab_size,
+        block_size=args.block_size,
+        n_layer=args.n_layer,
+        n_head=args.n_head,
+        n_embd=args.n_embd,
+    )
+    model = GPT(mconf)
+
+    fs = get_filesystem(args.input_path)
+    with fs.open(args.input_path, "rb") as f:
+        model.load_state_dict(torch.load(f, map_location="cuda:0"))
+
+    # quantize the model. Note that dynamic Quantization currently only 
+    # supports nn.Linear and nn.LSTM in qconfig_spec
+    model_quantized = torch.quantization.quantize_dynamic(
+        model, qconfig_spec={torch.nn.Linear}, dtype=torch.qint8
+    )
+
+    fs = get_filesystem(args.output_path)
+    with fs.open(args.output_path, "wb") as f:
+        torch.save(model_quantized, f)
+    print(f"exported model to {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/torchrecipes/paved_path/charnn/trainer.py
+++ b/torchrecipes/paved_path/charnn/trainer.py
@@ -14,7 +14,7 @@ from typing import Dict, Optional
 import fsspec
 import torch
 import torch.optim as optim
-from torch.nn import Module
+from torch.nn import functional as F, Module
 from torch.utils.data import Dataset
 from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.distributed import DistributedSampler
@@ -91,8 +91,8 @@ class Trainer:
 
     def run_batch(self, x, y, train: bool = True) -> float:
         with torch.set_grad_enabled(train):
-            _, loss = self.model(x, y)
-
+            logits = self.model(x)
+            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), y.view(-1))
         if train:
             self.model.zero_grad()
             loss.backward()

--- a/torchrecipes/paved_path/charnn/trainer.py
+++ b/torchrecipes/paved_path/charnn/trainer.py
@@ -161,16 +161,19 @@ class Trainer:
                 self.tb_writer.flush()
 
     def fit(self, app_state: Dict[str, Stateful], max_iter: int = -1) -> None:
+        snapshot_path = ""
         progress = app_state["progress"]
         for epoch in range(progress["current_epoch"], self.config.max_epochs):
             self.run_epoch(epoch, max_iter)
             progress["current_epoch"] += 1
 
             # save a snapshot per epoch
-            snapshot = Snapshot.take(
-                path=os.path.join(
+            if epoch == self.config.max_epochs - 1:
+                snapshot_path = os.path.join(self.config.work_dir, "snapshots/last")
+            else:
+                snapshot_path = os.path.join(
                     self.config.work_dir, f"snapshots/epoch-{progress['current_epoch']}"
-                ),
-                app_state=app_state,
-            )
+                )
+            snapshot = Snapshot.take(path=snapshot_path, app_state=app_state)
             logger.info(f"Saving snapshot to {snapshot.path}")
+        return snapshot_path

--- a/torchrecipes/paved_path/charnn/trainer.py
+++ b/torchrecipes/paved_path/charnn/trainer.py
@@ -11,6 +11,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Optional
 
+import fsspec
 import torch
 import torch.optim as optim
 from torch.nn import Module
@@ -19,8 +20,6 @@ from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.tensorboard import SummaryWriter
 from torchsnapshot import Snapshot, Stateful
-
-from utils import get_filesystem
 
 logger = logging.getLogger(__name__)
 
@@ -164,8 +163,8 @@ class Trainer:
                 self.tb_writer.flush()
 
     def export(self, model: Module, path: str) -> None:
-        fs = get_filesystem(path)
-        dirname = os.path.dirname(path)
+        fs, p = fsspec.core.url_to_fs(path)
+        dirname = os.path.dirname(p)
         if not fs.exists(dirname):
             fs.mkdirs(dirname)
 

--- a/torchrecipes/paved_path/charnn/trainer.py
+++ b/torchrecipes/paved_path/charnn/trainer.py
@@ -162,17 +162,6 @@ class Trainer:
             if self.tb_writer:
                 self.tb_writer.flush()
 
-    def export(self, model: Module, path: str) -> None:
-        fs, p = fsspec.core.url_to_fs(path)
-        dirname = os.path.dirname(p)
-        if not fs.exists(dirname):
-            fs.mkdirs(dirname)
-
-        logger.info(f"Exporting model to {path}")
-        model.eval()
-        with fs.open(path, "wb") as f:
-            torch.save(model.state_dict(), f)
-
     def fit(self, app_state: Dict[str, Stateful], max_iter: int = -1) -> None:
         snapshot_path = ""
         progress = app_state["progress"]
@@ -189,7 +178,4 @@ class Trainer:
                 )
             snapshot = Snapshot.take(path=snapshot_path, app_state=app_state)
             logger.info(f"Saving snapshot to {snapshot.path}")
-
-        model_path = os.path.join(self.config.work_dir, "models/last.pt")
-        self.export(app_state["model"].module, model_path)
         return snapshot_path

--- a/torchrecipes/paved_path/charnn/trainer_config.yaml
+++ b/torchrecipes/paved_path/charnn/trainer_config.yaml
@@ -6,6 +6,8 @@ dataset:
 max_iter: 200
 trainer:
   work_dir: "/tmp/charnn"
+  # each run's outputs will be saved under work_dir/job_name. If not specified, job_name will be auto-generated.
+  job_name: ""
   max_epochs: 1
   lr: 0.0006
   batch_size: 128

--- a/torchrecipes/paved_path/charnn/utils.py
+++ b/torchrecipes/paved_path/charnn/utils.py
@@ -6,8 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Optional
+from typing import Any, Optional
 
+import fsspec
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -68,3 +69,11 @@ def get_realpath(path: str) -> str:
 
     work_dir = os.path.dirname(__file__)
     return os.path.join(work_dir, path)
+
+
+def get_filesystem(path: str) -> Any:
+    if path.startswith("s3"):
+        fs = fsspec.filesystem("s3")
+    else:
+        fs = fsspec.filesystem("file")
+    return fs

--- a/torchrecipes/paved_path/charnn/utils.py
+++ b/torchrecipes/paved_path/charnn/utils.py
@@ -69,11 +69,3 @@ def get_realpath(path: str) -> str:
 
     work_dir = os.path.dirname(__file__)
     return os.path.join(work_dir, path)
-
-
-def get_filesystem(path: str) -> Any:
-    if path.startswith("s3"):
-        fs = fsspec.filesystem("s3")
-    else:
-        fs = fsspec.filesystem("file")
-    return fs

--- a/torchrecipes/paved_path/charnn/utils.py
+++ b/torchrecipes/paved_path/charnn/utils.py
@@ -6,9 +6,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Any, Optional
+from typing import Optional
 
-import fsspec
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -44,7 +43,7 @@ def sample(
         x_cond = (
             x if x.size(1) <= block_size else x[:, -block_size:]
         )  # crop context if needed
-        logits, _ = model(x_cond)
+        logits = model(x_cond)
         # pluck the logits at the final step and scale by temperature
         logits = logits[:, -1, :] / temperature
         # optionally crop probabilities to only the top k options

--- a/torchrecipes/paved_path/requirements.txt
+++ b/torchrecipes/paved_path/requirements.txt
@@ -4,3 +4,4 @@ hydra-core
 fsspec
 --pre
 torchsnapshot-nightly
+fsspec[s3]


### PR DESCRIPTION
It's troublesome to deal with transform and model separately during torchscript, quantization and deploy with torchserve. So I added `CombinedModule` wrapper to hold them such that it can consume raw input(text) and produce the prediction(generated text) end to end.