### PR TITLE
Randomize num ids per feature

### DIFF
--- a/torchrecipes/rec/datamodules/random_rec_datamodule.py
+++ b/torchrecipes/rec/datamodules/random_rec_datamodule.py
@@ -38,6 +38,9 @@ class RandomRecDataModule(pl.LightningDataModule):
         ids_per_feature: int = 2,
         num_dense: int = 50,
         num_workers: int = 0,
+        *,
+        num_generated_batches: int = 10,
+        min_ids_per_features: Optional[int] = None,
     ) -> None:
         super().__init__()
         self.keys: List[str] = keys if keys else ["f1", "f3", "f2"]
@@ -47,6 +50,8 @@ class RandomRecDataModule(pl.LightningDataModule):
         self.hash_size = hash_size
         self.hash_sizes = hash_sizes
         self.ids_per_feature = ids_per_feature
+        self.min_ids_per_feature = min_ids_per_features
+        self.num_generated_batches = num_generated_batches
         self.num_dense = num_dense
         self.num_workers = num_workers
         self.init_loader: DataLoader = DataLoader(
@@ -57,7 +62,9 @@ class RandomRecDataModule(pl.LightningDataModule):
                 hash_sizes=self.hash_sizes,
                 manual_seed=self.manual_seed,
                 ids_per_feature=self.ids_per_feature,
+                min_ids_per_feature=self.min_ids_per_feature,
                 num_dense=self.num_dense,
+                num_generated_batches=self.num_generated_batches,
             ),
             batch_size=None,
             batch_sampler=None,

--- a/torchrecipes/rec/datamodules/tests/test_random_rec_datamodule.py
+++ b/torchrecipes/rec/datamodules/tests/test_random_rec_datamodule.py
@@ -13,9 +13,9 @@ from torchrecipes.rec.datamodules.random_rec_datamodule import RandomRecDataModu
 
 class TestRandomRecDataModule(testslide.TestCase):
     def test_manual_seed_generator(self) -> None:
-        dm1 = RandomRecDataModule(manual_seed=353434)
+        dm1 = RandomRecDataModule(manual_seed=353434, min_ids_per_features=2)
         iterator1 = iter(dm1.init_loader)
-        dm2 = RandomRecDataModule(manual_seed=353434)
+        dm2 = RandomRecDataModule(manual_seed=353434, min_ids_per_features=2)
         iterator2 = iter(dm2.init_loader)
 
         for _ in range(10):
@@ -35,9 +35,9 @@ class TestRandomRecDataModule(testslide.TestCase):
             self.assertTrue(torch.equal(batch1.labels, batch2.labels))
 
     def test_no_manual_seed_generator(self) -> None:
-        dm1 = RandomRecDataModule()
+        dm1 = RandomRecDataModule(min_ids_per_features=2)
         iterator1 = iter(dm1.init_loader)
-        dm2 = RandomRecDataModule()
+        dm2 = RandomRecDataModule(min_ids_per_features=2)
         iterator2 = iter(dm2.init_loader)
 
         for _ in range(10):

--- a/torchrecipes/rec/modules/tests/test_lightning_dlrm.py
+++ b/torchrecipes/rec/modules/tests/test_lightning_dlrm.py
@@ -70,7 +70,9 @@ class TestLightningDLRM(unittest.TestCase):
                 over_arch_layer_sizes=[5, 1],
             )
 
-            datamodule = RandomRecDataModule(manual_seed=564733621, num_dense=num_dense)
+            datamodule = RandomRecDataModule(
+                manual_seed=564733621, num_dense=num_dense, num_generated_batches=1
+            )
 
             lit_models.append(lit_model)
             datamodules.append(datamodule)


### PR DESCRIPTION
Summary: To be a good citizen, I changed the default behavior to sample from 0 to num ids. This necessitated fixing some unit tests which had assumed that the number of ids would be fixed. I can also NOT change the default, but it seems like a good idea for the random dataset to actually have random ids by default.

Differential Revision: D48569957

